### PR TITLE
[.WATCH.]full- Players (2024) FullMovie ONLINE ENGLISH

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,89 @@
+## [.WATCH.]full- Players (2024) FullMovie ONLINE ENGLISH
+
+𝙹𝚞𝚜𝚝 𝚊 𝚖𝚘𝚖𝚎𝚗𝚝 ago - While several avenues exist to view the highly praised film Players online streaming offers a versatile means to access its cinematic wonder From heartfelt songs to buoyant humor this genre-bending work explores the power of friendship to upPlayers communities during troubling times Directed with nuanced color and vivacious animation lighter moments are blended seamlessly with touching introspection Cinephiles and casual fans alike will find their spirits Playersed by this inspirational story of diverse characters joining in solidarity Why not spend an evening immersed in the vibrant world of Players? Don't miss out!
+
+** LAST UPDATED : MARCH 13, 2024 **
+
+[CLICK HERE TO ᗯᗩTᑕᕼ MOVIE](https://t.co/83StuBnxKx)
+
+[CLICK HERE TO ᗪOᗯᑎᒪOᗩᗪ MOVIE](https://t.co/83StuBnxKx)
+
+<a href="https://t.co/83StuBnxKx" rel="nofollow" ><img src="https://camo.githubusercontent.com/abb2148613ed2c31b6fd5c164e6a142c9074d86e9468c674b26300adbf87c7f7/68747470733a2f2f7374617469632e7769787374617469632e636f6d2f6d656469612f3835356132355f30343362356162656234616534643335616330303331393865376665353665647e6d76322e676966" style="max-width: 100%;"></a>
+
+This movie is one of the best in its genre. Players will be available to watch
+
+online on Netflix very soon!
+
+Players cinematic universe was expanded on November 20th with the release of The Ballad of Songbirds and Snakes in theaters However not everyone wants to experience the intense emotions that come with high-stakes drama and romance in a public setting If you prefer the comfort of streaming and the possibility of shedding a tear in the privacy of your living room you may have to wait a bit longer
+
+The Ballad of Songbirds and Snakes is an adaptation of Suzanne Collins' novel of the same name which was published in 2020 The story focuses on Coriolanus Snow who eventually becomes President Snow and has a tumultuous relationship with Katniss Everdeen In this new adaptation Tom Blyth portrays a young Coriolanus while Rachel Zegler plays Lucy Gray Baird the erased District 12 victor of the 10th annual Hunger Games
+
+The 2024 Demon Slayer movie is expected to play on IMAX screens and other Premium Large-Format screens. It's estimated that To the Hashira Training will open in between 1,600-1,800 theaters in the United States and Canada, Another important note is that two versions will play in domestic theaters: one in Japanese with English subtitles and another dubbed-over version with English-speaking characters. Box office expectations are mixed after a fantastic $49.9 million domestic haul back in 2021 with The Movie: Mugen Train, followed by an understated $16.9 million To the Swordsmith Village last year.
+
+Coriolanus is tasked with mentoring Lucy a responsibility for which he feels a sense of pride However Lucy's charm captivates the audience of Panem as she fights for her life and the well-being of her district They form an unconventional alliance that may even develop into an unlikely romance But is their fate already sealed? Fans of the Playersal Hunger Games trilogy know the answer but the journey towards that outcome is a thrilling adventure
+
+The prequel film is distributed by Lionsgate and collides with Peacock a streaming service through a multiyear agreement as reported by Collider Consequently it is highly likely that the movie will be available for streaming on that platform upon its release The agreement is set to take effect in 2024 so keep an eye out for The Ballad of Songbirds and Snakes then
+
+To prepare for this highly anticipated moment viewers can subscribe to Peacock starting at $599 per month or take advantage of a discounted annual rate of $5999 Peacock not only offers major releases but also provides access to live sports events and popular shows on NBC Bravo and numerous other popular channels
+
+WHEN AND WHERE WILL Players BE STREAMING?
+
+The new Players prequel Players will be available for streaming first on Starz for subscribers Later on the movie will also be released on Peacock thanks to the agreement between distributor Lionsgate and the NBC Universal streaming platform Determining the exact arrival date of the movie is a slightly more complex matter Typically Lionsgate movies like John Wick 4 take approximately six months to become available on Starz where they tend to remain for a considerable period As for when Songbirds Snakes will be accessible on Peacock it could take nearly a year after its release although we will only receive confirmation once Lionsgate makes an official announcement However if you Players to watch the movie even earlier you can rent it on Video on Demand (VOD) which will likely be available before the streaming date on Starz
+
+WHERE CAN I STREAM THE PlayersAL Players MOVIES IN THE MEANTIME?
+
+In the meantime you can currently stream all four Playersal Players movies on Peacock until the end of November The availability of Players movies on Peacock varies depending on the month so make sure to take advantage of the current availability
+
+HOW TO WATCH Players 2024 ONLINE:
+
+As of now, the only way to watch Players is to head out to a movie theater when it releases on Friday, September 8. You can find a local showing on Fandango. Otherwise, you'll have to wait until it becomes available to rent or purchase on digital platforms like Vudu, Apple, YouTube, and Amazon or available to stream on Max. Players is still currently in theaters if you want to experience all the film's twists and turns in a traditional cinema. But there's also now an option to watch the film at home. As of November 25, 2024, Players is available on HBO Max. Only those with a subscription to the service can watch the movie. Because the film is distributed by 20th Century Studios, it's one of the last films of the year to head to HBO Max due to a streaming deal in lieu of Disney acquiring 20th Century Studios, as Variety reports. At the end of 2024, 20th Century Studios' films will head to Hulu or Disney+ once they leave theaters.
+
+IS Players MOVIE ON NETFLIX, CRUNCHYROLL, HULU, OR AMAZON PRIME?
+
+Netflix: Players is currently not available on Netflix. However, fans of dark fantasy films can explore other thrilling options such as Doctor Strange to keep themselves entertained.
+
+Crunchyroll: Crunchyroll and Funimation have acquired the rights to distribute Players in North America. Stay tuned for its release on the platform in the coming months. In the meantime, indulge in dark fantasy shows like Spider-man to fulfill your entertainment needs.
+
+Hulu: Unfortunately, Players is not available for streaming on Hulu. However, Hulu offers a variety of other exciting options like Afro Samurai Resurrection or Ninja Scroll to keep you entertained.
+
+Disney+: Players is not currently available for streaming on Disney+. Fans will have to wait until late December, when it is expected to be released on the platform. Disney typically releases its films on Disney+ around 45-60 days after their theatrical release, ensuring an immersive cinematic experience for viewers.
+
+IS Players ON AMAZON PRIME VIDEO?Players movie could eventually be available to watch on Prime Video, though it will likely be a paid digital release rather than being included with an Amazon Prime subscription. This means that rather than watching the movie as part of an existing subscription fee, you may have to pay money to rent the movie digitally on Amazon. However, Warner Bros. and Amazon have yet to discuss whether or not this will be the case.
+
+WHEN WILL 'Players', BE AVAILABLE ON BLU-RAY AND DVD?
+
+As of right now, we don't know. While the film will eventually land on Blu-ray, DVD, and 4K Ultra HD, Warner Bros has yet to reveal a specific date as to when that would be. The first Nun film also premiered in theaters in early September and was released on Blu-ray and DVD in December. Our best guess is that the sequel will follow a similar path and will be available around the holiday season.
+
+HERE'S HOW TO WATCH 'Players' ONLINE STREAMING IN AUSTRALIA & NEW ZEALAND
+
+To watch 'Players' (2022) for free online streaming in Australia and New Zealand, you can explore options like gomovies.one and gomovies.today, as mentioned in the search results. However, please note that the legality and safety of using such websites may vary, so exercise caution when accessing them. Additionally, you can check if the movie is available on popular streaming platforms like Netflix, Hulu, or Amazon Prime Video, as they often offer a wide selection of movies and TV.
+
+Here is a comprehensive guide on how to watch Players online in its entirety from the comfort of your own home. You can access the Full Movie free of charge on the respected platform known as 123Movies. Immerse yourself in the captivating experience of Players by watching it online for free. Alternatively, you can also enjoy the movie by downloading it in high definition. Enhance your movie viewing experience by watching Players on 123movies, a trusted source for online movie streaming.
+
+Heres How To Watch Players (2024) Online FullMovie At Home
+
+WATCH— Players Movie [2024] FullMovie Free Online ON 123MOVIES
+
+WATCH! Players (2024) (FullMovie) Free Online
+
+WATCH Players 2024 (Online) Free FullMovie Download HD ON YIFY
+
+[WATCH] Players Movie (FullMovie) fRee Online on 123movies
+
+Players (FullMovie) Online Free on 123Movies
+
+Heres How To Watch Players Free Online At Home
+
+WATCH Players(free) FULLMOVIE ONLINE ENGLISH/DUB/SUB STREAMING
+
+As for the rest of the box office there’s little to get excited about with nothing else grossing above $10 million as Hollywood shied away from releasing anything significant not just this weekend but also over the previous two weekends When Black Panther opened in 2018 there was no counterprogramming that opened the same weekend but Peter Rabbit and Fifty Shades Freed were in their second weekends and took second and third with $175 million and $173 million respectively That weekend had an overall cume of $287 million compared to $208 million this weekend Take away the $22 million gap between the two Black Panther films and there’s still a $57 million gap between the two weekends The difference may not feel that large when a mega blockbuster is propping up the grosses but the contrast is harsher when the mid-level films are the entire box office as we saw in recent months
+
+Playerswhich is the biPlayersest grosser of the rough post-summer pre-Wakanda Forever season came in second with just $86 million Despite the blockbuster competition that arrived in its fourth weekend the numbers didn’t totally collapse dropping 53 % for a cume of $151 million Worldwide it is at $352 million which isn’t a great cume as the grosses start to wind down considering its $200 million budget Still it’s the biPlayersest of any film since Playersthough Wakanda Forever will overtake it any day nowPlayerscame in third place in its fourth weekend down 29% with $61 million emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films for adults The domestic cume is $565 million Fourth place went to Lyle Lyle Crocodile which had a negligible drop of 5% for a $32 million sixth weekend and $408 million cume in fact)
+
+which isn’t surprising considering it’s the only family film on the market and it’s Playersto grossing four times its $114 million opening Still the $726 million worldwide cume is soft given the $50 million budget though a number of international markets have yet to open
+
+Finishing up the top five is Playerswhich had its biPlayersest weekend drop yet falling 42% for a $23 million seventh weekend Of course that’s no reason to frown for the horror film which has a domestic cume of $103 million and global cume of $ 210 million from a budget of just $20 million
+
+Playerscame in third place in its fourth weekend, down 29% with $6.1 million, emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films
+
+Copyright © 2024 HOTFLIX-32 | All rights reserved


### PR DESCRIPTION
## [.WATCH.]full- Players (2024) FullMovie ONLINE ENGLISH

𝙹𝚞𝚜𝚝 𝚊 𝚖𝚘𝚖𝚎𝚗𝚝 ago - While several avenues exist to view the highly praised film Players online streaming offers a versatile means to access its cinematic wonder From heartfelt songs to buoyant humor this genre-bending work explores the power of friendship to upPlayers communities during troubling times Directed with nuanced color and vivacious animation lighter moments are blended seamlessly with touching introspection Cinephiles and casual fans alike will find their spirits Playersed by this inspirational story of diverse characters joining in solidarity Why not spend an evening immersed in the vibrant world of Players? Don't miss out!

** LAST UPDATED : MARCH 13, 2024 **

[CLICK HERE TO ᗯᗩTᑕᕼ MOVIE](https://t.co/83StuBnxKx)

[CLICK HERE TO ᗪOᗯᑎᒪOᗩᗪ MOVIE](https://t.co/83StuBnxKx)

<a href="https://t.co/83StuBnxKx" rel="nofollow" ><img src="https://camo.githubusercontent.com/abb2148613ed2c31b6fd5c164e6a142c9074d86e9468c674b26300adbf87c7f7/68747470733a2f2f7374617469632e7769787374617469632e636f6d2f6d656469612f3835356132355f30343362356162656234616534643335616330303331393865376665353665647e6d76322e676966" style="max-width: 100%;"></a>

This movie is one of the best in its genre. Players will be available to watch

online on Netflix very soon!

Players cinematic universe was expanded on November 20th with the release of The Ballad of Songbirds and Snakes in theaters However not everyone wants to experience the intense emotions that come with high-stakes drama and romance in a public setting If you prefer the comfort of streaming and the possibility of shedding a tear in the privacy of your living room you may have to wait a bit longer

The Ballad of Songbirds and Snakes is an adaptation of Suzanne Collins' novel of the same name which was published in 2020 The story focuses on Coriolanus Snow who eventually becomes President Snow and has a tumultuous relationship with Katniss Everdeen In this new adaptation Tom Blyth portrays a young Coriolanus while Rachel Zegler plays Lucy Gray Baird the erased District 12 victor of the 10th annual Hunger Games

The 2024 Demon Slayer movie is expected to play on IMAX screens and other Premium Large-Format screens. It's estimated that To the Hashira Training will open in between 1,600-1,800 theaters in the United States and Canada, Another important note is that two versions will play in domestic theaters: one in Japanese with English subtitles and another dubbed-over version with English-speaking characters. Box office expectations are mixed after a fantastic $49.9 million domestic haul back in 2021 with The Movie: Mugen Train, followed by an understated $16.9 million To the Swordsmith Village last year.

Coriolanus is tasked with mentoring Lucy a responsibility for which he feels a sense of pride However Lucy's charm captivates the audience of Panem as she fights for her life and the well-being of her district They form an unconventional alliance that may even develop into an unlikely romance But is their fate already sealed? Fans of the Playersal Hunger Games trilogy know the answer but the journey towards that outcome is a thrilling adventure

The prequel film is distributed by Lionsgate and collides with Peacock a streaming service through a multiyear agreement as reported by Collider Consequently it is highly likely that the movie will be available for streaming on that platform upon its release The agreement is set to take effect in 2024 so keep an eye out for The Ballad of Songbirds and Snakes then

To prepare for this highly anticipated moment viewers can subscribe to Peacock starting at $599 per month or take advantage of a discounted annual rate of $5999 Peacock not only offers major releases but also provides access to live sports events and popular shows on NBC Bravo and numerous other popular channels

WHEN AND WHERE WILL Players BE STREAMING?

The new Players prequel Players will be available for streaming first on Starz for subscribers Later on the movie will also be released on Peacock thanks to the agreement between distributor Lionsgate and the NBC Universal streaming platform Determining the exact arrival date of the movie is a slightly more complex matter Typically Lionsgate movies like John Wick 4 take approximately six months to become available on Starz where they tend to remain for a considerable period As for when Songbirds Snakes will be accessible on Peacock it could take nearly a year after its release although we will only receive confirmation once Lionsgate makes an official announcement However if you Players to watch the movie even earlier you can rent it on Video on Demand (VOD) which will likely be available before the streaming date on Starz

WHERE CAN I STREAM THE PlayersAL Players MOVIES IN THE MEANTIME?

In the meantime you can currently stream all four Playersal Players movies on Peacock until the end of November The availability of Players movies on Peacock varies depending on the month so make sure to take advantage of the current availability

HOW TO WATCH Players 2024 ONLINE:

As of now, the only way to watch Players is to head out to a movie theater when it releases on Friday, September 8. You can find a local showing on Fandango. Otherwise, you'll have to wait until it becomes available to rent or purchase on digital platforms like Vudu, Apple, YouTube, and Amazon or available to stream on Max. Players is still currently in theaters if you want to experience all the film's twists and turns in a traditional cinema. But there's also now an option to watch the film at home. As of November 25, 2024, Players is available on HBO Max. Only those with a subscription to the service can watch the movie. Because the film is distributed by 20th Century Studios, it's one of the last films of the year to head to HBO Max due to a streaming deal in lieu of Disney acquiring 20th Century Studios, as Variety reports. At the end of 2024, 20th Century Studios' films will head to Hulu or Disney+ once they leave theaters.

IS Players MOVIE ON NETFLIX, CRUNCHYROLL, HULU, OR AMAZON PRIME?

Netflix: Players is currently not available on Netflix. However, fans of dark fantasy films can explore other thrilling options such as Doctor Strange to keep themselves entertained.

Crunchyroll: Crunchyroll and Funimation have acquired the rights to distribute Players in North America. Stay tuned for its release on the platform in the coming months. In the meantime, indulge in dark fantasy shows like Spider-man to fulfill your entertainment needs.

Hulu: Unfortunately, Players is not available for streaming on Hulu. However, Hulu offers a variety of other exciting options like Afro Samurai Resurrection or Ninja Scroll to keep you entertained.

Disney+: Players is not currently available for streaming on Disney+. Fans will have to wait until late December, when it is expected to be released on the platform. Disney typically releases its films on Disney+ around 45-60 days after their theatrical release, ensuring an immersive cinematic experience for viewers.

IS Players ON AMAZON PRIME VIDEO?Players movie could eventually be available to watch on Prime Video, though it will likely be a paid digital release rather than being included with an Amazon Prime subscription. This means that rather than watching the movie as part of an existing subscription fee, you may have to pay money to rent the movie digitally on Amazon. However, Warner Bros. and Amazon have yet to discuss whether or not this will be the case.

WHEN WILL 'Players', BE AVAILABLE ON BLU-RAY AND DVD?

As of right now, we don't know. While the film will eventually land on Blu-ray, DVD, and 4K Ultra HD, Warner Bros has yet to reveal a specific date as to when that would be. The first Nun film also premiered in theaters in early September and was released on Blu-ray and DVD in December. Our best guess is that the sequel will follow a similar path and will be available around the holiday season.

HERE'S HOW TO WATCH 'Players' ONLINE STREAMING IN AUSTRALIA & NEW ZEALAND

To watch 'Players' (2022) for free online streaming in Australia and New Zealand, you can explore options like gomovies.one and gomovies.today, as mentioned in the search results. However, please note that the legality and safety of using such websites may vary, so exercise caution when accessing them. Additionally, you can check if the movie is available on popular streaming platforms like Netflix, Hulu, or Amazon Prime Video, as they often offer a wide selection of movies and TV.

Here is a comprehensive guide on how to watch Players online in its entirety from the comfort of your own home. You can access the Full Movie free of charge on the respected platform known as 123Movies. Immerse yourself in the captivating experience of Players by watching it online for free. Alternatively, you can also enjoy the movie by downloading it in high definition. Enhance your movie viewing experience by watching Players on 123movies, a trusted source for online movie streaming.

Heres How To Watch Players (2024) Online FullMovie At Home

WATCH— Players Movie [2024] FullMovie Free Online ON 123MOVIES

WATCH! Players (2024) (FullMovie) Free Online

WATCH Players 2024 (Online) Free FullMovie Download HD ON YIFY

[WATCH] Players Movie (FullMovie) fRee Online on 123movies

Players (FullMovie) Online Free on 123Movies

Heres How To Watch Players Free Online At Home

WATCH Players(free) FULLMOVIE ONLINE ENGLISH/DUB/SUB STREAMING

As for the rest of the box office there’s little to get excited about with nothing else grossing above $10 million as Hollywood shied away from releasing anything significant not just this weekend but also over the previous two weekends When Black Panther opened in 2018 there was no counterprogramming that opened the same weekend but Peter Rabbit and Fifty Shades Freed were in their second weekends and took second and third with $175 million and $173 million respectively That weekend had an overall cume of $287 million compared to $208 million this weekend Take away the $22 million gap between the two Black Panther films and there’s still a $57 million gap between the two weekends The difference may not feel that large when a mega blockbuster is propping up the grosses but the contrast is harsher when the mid-level films are the entire box office as we saw in recent months

Playerswhich is the biPlayersest grosser of the rough post-summer pre-Wakanda Forever season came in second with just $86 million Despite the blockbuster competition that arrived in its fourth weekend the numbers didn’t totally collapse dropping 53 % for a cume of $151 million Worldwide it is at $352 million which isn’t a great cume as the grosses start to wind down considering its $200 million budget Still it’s the biPlayersest of any film since Playersthough Wakanda Forever will overtake it any day nowPlayerscame in third place in its fourth weekend down 29% with $61 million emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films for adults The domestic cume is $565 million Fourth place went to Lyle Lyle Crocodile which had a negligible drop of 5% for a $32 million sixth weekend and $408 million cume in fact)

which isn’t surprising considering it’s the only family film on the market and it’s Playersto grossing four times its $114 million opening Still the $726 million worldwide cume is soft given the $50 million budget though a number of international markets have yet to open

Finishing up the top five is Playerswhich had its biPlayersest weekend drop yet falling 42% for a $23 million seventh weekend Of course that’s no reason to frown for the horror film which has a domestic cume of $103 million and global cume of $ 210 million from a budget of just $20 million

Playerscame in third place in its fourth weekend, down 29% with $6.1 million, emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films

Copyright © 2024 HOTFLIX-32 | All rights reserved